### PR TITLE
Rebuild 808 generator package and add regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+

--- a/generators/__init__.py
+++ b/generators/__init__.py
@@ -1,0 +1,65 @@
+"""Preset generators for HipHopGen.
+
+The original project exposed a :func:`make_808` helper that returned a
+preconfigured 808-style bass instrument.  The function disappeared during a
+refactor which left downstream projects without a way to construct the preset.
+This module restores that public API while keeping the implementation simple
+and easy to extend.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from .music import Key, add_octave, parse_key
+from .presets import BassPreset, Envelope, Glide
+
+__all__ = ["BassPreset", "Envelope", "Glide", "Key", "make_808"]
+
+
+DEFAULT_ROOT_CYCLE = (1, 7, 5, 6)
+
+
+def _root_cycle(key: Key, degrees: Sequence[int], *, octave: int) -> Sequence[str]:
+    notes = (key.degree(degree) for degree in degrees)
+    return add_octave(notes, octave)
+
+
+def make_808(key: str = "A minor", *, octave: int = 2, description: str | None = None,
+             extra_degrees: Iterable[int] | None = None) -> BassPreset:
+    """Return an 808-style bass preset aligned with ``key``.
+
+    Parameters
+    ----------
+    key:
+        Textual representation of the musical key.  Examples include
+        ``"A minor"`` (default) or ``"C# major"``.  Only natural major and
+        minor modes are supported at present.
+    octave:
+        Octave number used when attaching octaves to scale degrees.
+    description:
+        Optional descriptive text stored on the preset instance.
+    extra_degrees:
+        Optional iterable of additional scale degrees appended to the default
+        cycle.  This makes it simple for callers to extend the root motion
+        while still keeping the default behaviour consistent with the original
+        implementation.
+    """
+
+    key_obj = parse_key(key)
+    degrees = list(DEFAULT_ROOT_CYCLE)
+    if extra_degrees:
+        degrees.extend(extra_degrees)
+    root_cycle = _root_cycle(key_obj, degrees, octave=octave)
+    preset_description = description or "Classic 808 bass tuned to the project key."
+
+    envelope = Envelope(attack=0.01, decay=0.4, sustain=0.6, release=0.3)
+    glide = Glide(enabled=True, time=0.08)
+
+    return BassPreset(
+        name="808",
+        key=key_obj,
+        root_cycle=list(root_cycle),
+        envelope=envelope,
+        glide=glide,
+        description=preset_description,
+    )

--- a/generators/music.py
+++ b/generators/music.py
@@ -1,0 +1,145 @@
+"""Music theory helpers used by HipHopGen presets.
+
+The project intentionally keeps the implementation light weight. We model
+notes as simple strings (e.g. ``"A"`` or ``"Bb"``) and keys as a tonic plus a
+mode. Only natural minor and major modes are required for the current test
+suite but the module keeps the public API general enough to support future
+expansion.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+# Canonical order of the chromatic scale starting from C.
+NOTE_SEQUENCE: List[str] = [
+    "C",
+    "C#",
+    "D",
+    "D#",
+    "E",
+    "F",
+    "F#",
+    "G",
+    "G#",
+    "A",
+    "A#",
+    "B",
+]
+
+# A mapping of semitone index to a tuple of (sharp, flat) spellings.  Some
+# indices only have a single common spelling; ``None`` is used when a flat
+# variant is uncommon (e.g. there is no distinct flat name for ``E``).
+INDEX_TO_SPELLING = {
+    0: ("C", "C"),
+    1: ("C#", "Db"),
+    2: ("D", "D"),
+    3: ("D#", "Eb"),
+    4: ("E", "E"),
+    5: ("F", "F"),
+    6: ("F#", "Gb"),
+    7: ("G", "G"),
+    8: ("G#", "Ab"),
+    9: ("A", "A"),
+    10: ("A#", "Bb"),
+    11: ("B", "B"),
+}
+
+# Provide quick lookup of semitone index for any supported spelling.
+NOTE_TO_INDEX = {spelling: index for index, pair in INDEX_TO_SPELLING.items() for spelling in pair if spelling}
+
+
+@dataclass(frozen=True)
+class Key:
+    """Represents a musical key.
+
+    Attributes
+    ----------
+    tonic:
+        The root note of the key (``"A"``, ``"Bb"`` …).
+    scale_type:
+        A descriptive name such as ``"major"`` or ``"minor"``.
+    scale:
+        The seven note names that make up the diatonic scale for the key.
+    """
+
+    tonic: str
+    scale_type: str
+    scale: List[str]
+
+    def degree(self, number: int) -> str:
+        """Return the ``number``th scale degree using 1-based indexing."""
+        if number < 1:
+            raise ValueError("Scale degrees start at 1.")
+        return self.scale[(number - 1) % len(self.scale)]
+
+
+def _normalise_tonic(token: str) -> str:
+    token = token.strip().replace("♭", "b").replace("♯", "#")
+    if not token:
+        raise ValueError("The tonic of a key cannot be empty.")
+    token = token[0].upper() + token[1:]
+    if len(token) > 1 and token[1] in {"b", "#"}:
+        return token[0] + token[1]
+    return token[0]
+
+
+def parse_key(key_str: str) -> Key:
+    """Parse a key description such as ``"A minor"``."""
+    if not key_str:
+        raise ValueError("Key string must not be empty.")
+
+    parts = key_str.replace("-", " ").split()
+    if not parts:
+        raise ValueError(f"Unable to parse key from {key_str!r}.")
+
+    tonic = _normalise_tonic(parts[0])
+    mode = "major" if len(parts) == 1 else parts[1].lower()
+    if mode in {"minor", "min", "m"}:
+        scale_type = "minor"
+    elif mode in {"major", "maj", "M"}:
+        scale_type = "major"
+    else:
+        raise ValueError(f"Unsupported scale type: {mode!r}")
+
+    if tonic not in NOTE_TO_INDEX:
+        raise ValueError(f"Unsupported tonic: {tonic!r}")
+
+    scale = build_scale(tonic, scale_type)
+    return Key(tonic=tonic, scale_type=scale_type, scale=scale)
+
+
+INTERVALS = {
+    "major": (0, 2, 4, 5, 7, 9, 11),
+    "minor": (0, 2, 3, 5, 7, 8, 10),
+}
+
+
+def build_scale(tonic: str, scale_type: str) -> List[str]:
+    """Return a list of note names for the diatonic scale."""
+    if scale_type not in INTERVALS:
+        raise ValueError(f"Unsupported scale type: {scale_type}")
+
+    base_index = NOTE_TO_INDEX[tonic]
+    prefer_flats = scale_type == "minor"
+    spellings = []
+    for interval in INTERVALS[scale_type]:
+        index = (base_index + interval) % len(NOTE_SEQUENCE)
+        sharp, flat = INDEX_TO_SPELLING[index]
+        if prefer_flats and flat:
+            spellings.append(flat)
+        else:
+            spellings.append(sharp)
+    return spellings
+
+
+def add_octave(notes: Iterable[str], octave: int) -> List[str]:
+    """Attach an octave number to each note if one is not present."""
+    result = []
+    for note in notes:
+        # Preserve explicit octave markers supplied by the caller.
+        if any(ch.isdigit() for ch in note):
+            result.append(note)
+        else:
+            result.append(f"{note}{octave}")
+    return result

--- a/generators/presets.py
+++ b/generators/presets.py
@@ -1,0 +1,52 @@
+"""Runtime data structures describing synth presets."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .music import Key
+
+
+@dataclass(frozen=True)
+class Envelope:
+    """Simple ADSR-like envelope parameters for a synthesizer."""
+
+    attack: float = 0.005
+    decay: float = 0.3
+    sustain: float = 0.8
+    release: float = 0.4
+
+
+@dataclass(frozen=True)
+class Glide:
+    """Represents portamento controls for sliding between notes."""
+
+    enabled: bool = False
+    time: float = 0.0
+
+
+@dataclass(frozen=True)
+class BassPreset:
+    """Describes an 808-style bass preset."""
+
+    name: str
+    key: Key
+    root_cycle: List[str]
+    envelope: Envelope = field(default_factory=Envelope)
+    glide: Glide = field(default_factory=Glide)
+    description: str = ""
+
+    def as_dict(self) -> dict:
+        """Return a serialisable representation of the preset."""
+        return {
+            "name": self.name,
+            "key": {
+                "tonic": self.key.tonic,
+                "scale_type": self.key.scale_type,
+                "scale": list(self.key.scale),
+            },
+            "root_cycle": list(self.root_cycle),
+            "envelope": self.envelope.__dict__,
+            "glide": self.glide.__dict__,
+            "description": self.description,
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "hiphopgen"
+version = "0.1.0"
+description = "Reconstructed HipHopGen preset generators"
+readme = "Readme.md"
+requires-python = ">=3.10"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["."]

--- a/tests/test_808.py
+++ b/tests/test_808.py
@@ -1,0 +1,27 @@
+import pytest
+
+from generators import make_808
+
+
+def test_make_808_default_cycle_matches_a_minor():
+    preset = make_808()
+    assert preset.key.tonic == "A"
+    assert preset.key.scale_type == "minor"
+    assert preset.root_cycle == ["A2", "G2", "E2", "F2"]
+
+
+def test_cycle_stays_in_scale_for_other_keys():
+    preset = make_808("C minor")
+    assert preset.root_cycle[:4] == ["C2", "Bb2", "G2", "Ab2"]
+    for note in preset.root_cycle:
+        assert note[:-1] in preset.key.scale
+
+
+def test_extra_degrees_extend_cycle():
+    preset = make_808(extra_degrees=[4])
+    assert preset.root_cycle == ["A2", "G2", "E2", "F2", "D2"]
+
+
+def test_parse_key_rejects_unknown_mode():
+    with pytest.raises(ValueError):
+        make_808("A dorian")


### PR DESCRIPTION
## Summary
- restore the generators package with a public `make_808` helper
- add lightweight music theory and preset models needed at runtime
- configure pytest and add regression coverage for the 808 root cycle

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfda673d5883319821d4026d7e0a67